### PR TITLE
Made changes on Docker related files for Unix-based systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary packages
 RUN apt-get update -y && \
-    apt-get install -y wget curl bash sudo tzdata && \
+    apt-get install -y wget curl bash sudo tzdata git && \
     echo "Etc/UTC" > /etc/timezone && \
     ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
     dpkg-reconfigure --frontend noninteractive tzdata

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,11 +14,11 @@ services:
       - "8090:8090"
     volumes:
       - blackdagger:/home/blackdagger/.config/blackdagger
-      - ./dags:/home/blackdagger/.config/blackdagger/dags
-      - ./data:/home/blackdagger/.config/blackdagger/data
-      - ./logs:/home/blackdagger/.config/blackdagger/logs
-      - ./suspend:/home/blackdagger/.config/blackdagger/suspend
-    command: ["sh", "-c", "/usr/local/bin/startservices.sh"]
+      - ./dags:/home/blackdagger/.local/share/blackdagger/dags
+      - ./history:/home/blackdagger/.local/share/blackdagger/history
+      - ./logs:/home/blackdagger/.local/share/blackdagger/logs
+      - ./suspend:/home/blackdagger/.local/share/blackdagger/suspend
+    command: ["sh", "/usr/local/bin/startservices.sh"]
 
 volumes:
   blackdagger: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
       - ./history:/home/blackdagger/.local/share/blackdagger/history
       - ./logs:/home/blackdagger/.local/share/blackdagger/logs
       - ./suspend:/home/blackdagger/.local/share/blackdagger/suspend
-    command: ["sh", "/usr/local/bin/startservices.sh"]
 
 volumes:
   blackdagger: {}


### PR DESCRIPTION
Docker related files can now be used to run Blackdagger on a container located at a Unix-based system. 

These files can also be effective on Windows systems. However, there is a issue about container network settings that are run on Windows. Container can't be accessed via [::]:8080 but can be accessed with localhost:8080.